### PR TITLE
HAI-654 Create base Coder Ubuntu image

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,31 @@
+name: Build and publish
+
+on:
+  pull_request:
+    branches:
+      - main
+  release:
+    types: [published]
+
+jobs:
+  build:
+    name: Build and publish
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Build the image
+        run: make build
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v2
+        if: github.event_name == 'release'
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Publish the image
+        if: github.event_name == 'release'
+        run: make publish
+        env:
+          TAG: ${{ github.ref_name }}

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+
+.DEFAULT_GOAL := help
+IMAGE_NAME := harrisonai/coder-dev
+
+build:
+	./scripts/build.sh $(IMAGE_NAME)
+
+publish:
+	@test -n "${TAG}" || ( echo "TAG environment variable must be set" && return 1 )
+	./scripts/publish.sh $(IMAGE_NAME) ${TAG}
+
+help:
+	@sed -ne '/@sed/!s/## //p' $(MAKEFILE_LIST)

--- a/README.md
+++ b/README.md
@@ -1,2 +1,26 @@
 # cobalt-docker-coder-dev
-Docker images for Coder development
+
+Base Docker images for Coder development
+
+## 💡 Motivation
+Our goal is to provide a base Docker image for the [Coder](https://coder.com/) environment that allows developers to quickly get started with basic prerequisites for ML development.
+
+## 🔧 What’s inside ?
+
+Currently we provide a single image based on [Coder’s “Enterprise Base” Docker image](https://hub.docker.com/r/codercom/enterprise-base), with the following additional tools included:
+
+* Python 3.8
+* [AWS CLI](https://aws.amazon.com/cli/)
+* [Kubernetes CL tool (`kubectl`)](https://kubernetes.io/docs/reference/kubectl/)
+* other useful utilities (`ffmpeg`, `libsm6`, `libxext6`, `direnv`, `net-tools`, `iputils-ping`, `dnsutils`, `iproute2`, `tmux`, `bash-completion`, `zsh`)
+
+## 🚀 Usage
+
+To launch a CLI:
+
+```bash
+docker run -it --entrypoint /bin/bash harrisonai/coder-dev:base
+```
+
+## 📖 License
+This project is licensed under [Apache License 2.0](https://github.com/harrison-ai/cobalt-docker-coder-dev/blob/main/LICENSE).

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -3,11 +3,14 @@ FROM codercom/enterprise-base@sha256:f58cce5a5c00dca76e53a54aab3eea0fcac3be9875f
 
 USER root
 
-RUN apt-get update \
+RUN sed -i 's#/archive.ubuntu.com#/au.archive.ubuntu.com#g' /etc/apt/sources.list \
+    && apt-get update \
     && apt-get install --no-install-recommends -y \
+        apt-utils \
         bash-completion \
         ca-certificates \
         curl \
+        dialog \
         direnv \
         dnsutils \
         ffmpeg \
@@ -23,6 +26,8 @@ RUN apt-get update \
         tmux \
         unzip \
         zsh \
+    && apt-get upgrade -y \
+    && yes | unminimize \
     && rm -rf /var/lib/apt/lists/*
 
 RUN pip install -Uq pip pip-tools

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,0 +1,45 @@
+# Pinned to 2022-11-12 version of "ubuntu" tag
+FROM codercom/enterprise-base@sha256:f58cce5a5c00dca76e53a54aab3eea0fcac3be9875fd0b9bda1d8e16f6bf5c22
+
+USER root
+
+RUN apt-get update \
+    && apt-get install --no-install-recommends -y \
+        bash-completion \
+        ca-certificates \
+        curl \
+        direnv \
+        dnsutils \
+        ffmpeg \
+        git \
+        iproute2 \
+        iputils-ping \
+        libsm6 \
+        libxext6 \
+        net-tools \
+        openssh-client \
+        python3.8 \
+        python3.8-venv \
+        tmux \
+        unzip \
+        zsh \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN pip install -Uq pip pip-tools
+ENV PATH="${PATH}:/home/coder/.local/bin"
+
+ARG AWS_VERSION=2.7.18
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-${AWS_VERSION}.zip" -o "/tmp/awscliv2.zip" && \
+    unzip -q /tmp/awscliv2.zip -d /tmp && \
+    /tmp/aws/install && \
+    rm -rf /tmp/aws /tmp/awscliv2.zip
+
+ARG KUBE_VERSION=1.22.12
+RUN curl -LO "https://dl.k8s.io/release/v${KUBE_VERSION}/bin/linux/amd64/kubectl" && \
+    chmod +x kubectl && \
+    mv kubectl /usr/local/bin
+
+RUN ssh-keyscan github.com 2>/dev/null > /etc/ssh/ssh_known_hosts
+
+USER coder
+WORKDIR /home/coder

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# Builds the docker images
+
+set -e
+
+if [ "$#" -ne 1 ]; then
+    >&2 echo "Usage: $(basename $0) <image-name>"
+    exit 1
+fi
+
+IMAGE_NAME="$1"
+
+docker build -t "${IMAGE_NAME}:base" base

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+# Publishes images to Docker Hub
+
+# We expect this repo to one day contain multiple useful Coder images, but currently it
+# only has one option, 'base'. To keep tag names coherent, we're providing three ways to
+# reference variants:
+#   * by release number and variant name (e.g. harrisonai/coder-dev:0.1.0-base),
+#   * by variant name alone (e.g. harrisonai/coder-dev:base, which will always use the
+#     most recent release), and
+#   * by default/latest, which will always be the most recent release of 'base'.
+
+set -e
+
+if [ "$#" -ne 2 ]; then
+    >&2 echo "Usage: $(basename $0) <image-name> <version-tag>"
+    exit 1
+fi
+
+IMAGE_NAME="$1"
+VERSION="${2#v}"
+
+echo "🏷️ Adding tags for image '${IMAGE_NAME}:base': ${VERSION}-base, latest"
+docker tag "${IMAGE_NAME}:base" "${IMAGE_NAME}:${VERSION}-base"
+docker tag "${IMAGE_NAME}:base" "${IMAGE_NAME}:latest"
+
+echo "📤 Pushing '${IMAGE_NAME}:${TAG}-base', '${IMAGE_NAME}:base', and '${IMAGE_NAME}:latest'"
+docker push "${IMAGE_NAME}:${TAG}-base"
+docker push "${IMAGE_NAME}:base"
+docker push "${IMAGE_NAME}:latest"


### PR DESCRIPTION
This PR does the initial setup for a Coder images repo, starting with a base Ubuntu image that includes some common ML prerequisites (see [ticket](https://harrison-ai.atlassian.net/jira/software/projects/HAI/boards/80?selectedIssue=HAI-654) for full requirements).

Please also treat the repo itself as part of this PR; I've tried to configure it to behave similarly to our other repos, but I don't have admin rights on any others so I can't compare their settings directly. @andychisholm, @dcarrion87 and @schattingh, I've added you all as admins, so feel free to go ahead and make any corrections needed on that front.