### PR TITLE
HAI-915 Add jq command-line JSON processor

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -15,6 +15,7 @@ RUN sed -i 's#/archive.ubuntu.com#/au.archive.ubuntu.com#g' /etc/apt/sources.lis
         dnsutils \
         ffmpeg \
         git \
+        jq \
         iproute2 \
         iputils-ping \
         libsm6 \


### PR DESCRIPTION
## Related Tasks

- HAI-915

## What

- Add jq tool to base image: https://stedolan.github.io/jq/

## Why

- Handy for manipulating JSON in shell. Using it for startup script in future Coder template. [Related change here](https://github.com/harrison-ai/harrison-infra-hpc/pull/150).
