### PR TITLE
Update s5cmd to 2.1.0 to resolve memory issue during sync

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -53,7 +53,7 @@ ENV LC_ALL en_US.UTF-8
 RUN pip install -Uq pip pip-tools
 ENV PATH="${PATH}:/home/coder/.local/bin"
 
-ARG S5CMD_VERSION=2.0.0
+ARG S5CMD_VERSION=2.1.0
 RUN curl -L -o "/tmp/s5cmd.tar.gz" "https://github.com/peak/s5cmd/releases/download/v${S5CMD_VERSION}/s5cmd_${S5CMD_VERSION}_Linux-64bit.tar.gz" && \
     tar -xzf /tmp/s5cmd.tar.gz -C /tmp && \
     cp -p /tmp/s5cmd /usr/local/bin && \


### PR DESCRIPTION
## Related Tasks

- #11 
- https://github.com/peak/s5cmd/issues/447

## What

- s5cmd loads too much during sync. Switch to version where issue is resolved.

Note new features and breaking changes in Slack channels after release. https://github.com/peak/s5cmd/releases/tag/v2.1.0

## Why

- OOMs are bad.
