### PR TITLE
Update to latest sudo to avoid false warnings

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -76,6 +76,12 @@ RUN curl -LO "https://dl.k8s.io/release/v${KUBE_VERSION}/bin/linux/amd64/kubectl
     chmod +x kubectl && \
     mv kubectl /usr/local/bin
 
+# Workaround issue described here https://github.com/harrison-ai/cobalt-docker-coder-dev/issues/8
+# Until Ubuntu upgrade.
+RUN curl -L -o "/tmp/sudo.deb" https://github.com/sudo-project/sudo/releases/download/SUDO_1_9_14p3/sudo_1.9.14-4_ubu2004_amd64.deb && \
+    dpkg -i /tmp/sudo.deb && \
+    rm -rf /tmp/sudo.deb
+
 RUN ssh-keyscan github.com 2>/dev/null > /etc/ssh/ssh_known_hosts
 
 USER coder


### PR DESCRIPTION
## Related Tasks

- #8 

## What

- Update to latest sudo release.
- Can be tested specifying docker image `ghcr.io/harrison-ai/coder-dev:0.1.8-base-beta` during workspace start

## Why

- Remove warning messages per issue and to resolve internal coder issue.
