### PR TITLE
Include Python 3.11 by default in coder envs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ Our goal is to provide a base Docker image for the [Coder](https://coder.com/) e
 
 Currently we provide a single image based on [Coder’s “Enterprise Base” Docker image](https://hub.docker.com/r/codercom/enterprise-base), with the following additional tools included:
 
-* Python 3.8
+* Python 3.8 (`python3` would be symlinked to `python3.8`)
+* Python 3.11
 * [AWS CLI](https://aws.amazon.com/cli/)
 * [Kubernetes CL tool (`kubectl`)](https://kubernetes.io/docs/reference/kubectl/)
 * other useful utilities (`ffmpeg`, `libsm6`, `libxext6`, `direnv`, `net-tools`, `iputils-ping`, `dnsutils`, `iproute2`, `tmux`, `bash-completion`, `zsh`, `emacs`, `nano`)

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -4,6 +4,8 @@ FROM codercom/enterprise-base@sha256:991819021919f7e7132f8843f9b49de7c7072e6c4e1
 USER root
 
 RUN sed -i 's#/archive.ubuntu.com#/au.archive.ubuntu.com#g' /etc/apt/sources.list \
+    # Adding deadsnakes ppa to install more recent Python versions packaged for Ubuntu.
+    && add-apt-repository ppa:deadsnakes/ppa \
     && apt-get update \
     && apt-get install --no-install-recommends -y \
         apt-utils \
@@ -24,6 +26,8 @@ RUN sed -i 's#/archive.ubuntu.com#/au.archive.ubuntu.com#g' /etc/apt/sources.lis
         openssh-client \
         python3.8 \
         python3.8-venv \
+        python3.11 \
+        python3.11-venv \
         tmux \
         unzip \
         zsh \


### PR DESCRIPTION
Resolves https://harrison-ai.atlassian.net/browse/HPI-743

hai-ml v2.18.0 would drop support for Python 3.8 and move to 3.11 as min required version. We, therefore, want to preinstall Python 3.11.x on coder environments to help downstream users setup their py 3.11  venvs.