### PR TITLE
Update base image with libibverbs1 for non-ray distributed train

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -36,6 +36,9 @@ RUN sed -i 's#/archive.ubuntu.com#/au.archive.ubuntu.com#g' /etc/apt/sources.lis
         screen \
         # --- NVIDIA based utils ---
         nvtop \
+        # --- infiniband verbs are required for GPU-GPU commms --
+        libibverbs1 \
+        libibverbs-dev \
         # --- pyenv dependencies ---
         libssl-dev \
         libbz2-dev \


### PR DESCRIPTION
As discussed in this thread https://harrison-ai.slack.com/archives/C03S32UBFL2/p1721784801651469, it seems like ibverbs are missing from base coder image. This will be needed for multi-node distributed training. Since more workloads are moving away from ray based distributed training, it would be good to have it here. 