### PR TITLE
Adds zlib v1.3.1 into the base docker image

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -90,6 +90,19 @@ RUN curl -LO "https://dl.k8s.io/release/v${KUBE_VERSION}/bin/linux/amd64/kubectl
     chmod +x kubectl && \
     mv kubectl /usr/local/bin
 
+# zlib packed in ubuntu is of version 1.12.11,
+# while newer versions give faster reads of gz files.
+ARG ZLIB_VERSION=1.13.1
+https://github.com/madler/zlib/releases/download/v1.3.1/zlib131.zip
+RUN curl -L -o "/tmp/zlib.zip" "https://github.com/madler/zlib/releases/download/v${ZLIB_VERSION}/zlib${ZLIB_VERSION//./}.zip" && \
+    unzip /tmp/zlib.zip -d /tmp
+WORKDIR /tmp/zlib-${ZLIB_VERSION}
+RUN ./configure && \
+    make install
+WORKDIR /
+RUN rm -rf /tmp/zlib*
+
+
 # Workaround issue described here https://github.com/harrison-ai/cobalt-docker-coder-dev/issues/8
 # Until Ubuntu upgrade.
 RUN curl -L -o "/tmp/sudo.deb" https://github.com/sudo-project/sudo/releases/download/SUDO_1_9_14p3/sudo_1.9.14-4_ubu2004_amd64.deb && \

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -92,8 +92,7 @@ RUN curl -LO "https://dl.k8s.io/release/v${KUBE_VERSION}/bin/linux/amd64/kubectl
 
 # zlib packed in ubuntu is of version 1.12.11,
 # while newer versions give faster reads of gz files.
-ARG ZLIB_VERSION=1.13.1
-https://github.com/madler/zlib/releases/download/v1.3.1/zlib131.zip
+ARG ZLIB_VERSION=1.3.1
 RUN curl -L -o "/tmp/zlib.zip" "https://github.com/madler/zlib/releases/download/v${ZLIB_VERSION}/zlib${ZLIB_VERSION//./}.zip" && \
     unzip /tmp/zlib.zip -d /tmp
 WORKDIR /tmp/zlib-${ZLIB_VERSION}

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -94,13 +94,12 @@ RUN curl -LO "https://dl.k8s.io/release/v${KUBE_VERSION}/bin/linux/amd64/kubectl
 # while newer versions give faster reads of gz files.
 ARG ZLIB_VERSION=1.3.1
 RUN curl -L -o "/tmp/zlib.zip" "https://github.com/madler/zlib/releases/download/v${ZLIB_VERSION}/zlib${ZLIB_VERSION//./}.zip" && \
-    unzip /tmp/zlib.zip -d /tmp
-WORKDIR /tmp/zlib-${ZLIB_VERSION}
-RUN ./configure && \
-    make install
-WORKDIR /
-RUN rm -rf /tmp/zlib*
-
+    unzip /tmp/zlib.zip -d /tmp && \
+    cd /tmp/zlib-${ZLIB_VERSION} && \
+    ./configure && \
+    make install && \
+    cd / && \
+    rm -rf /tmp/zlib*
 
 # Workaround issue described here https://github.com/harrison-ai/cobalt-docker-coder-dev/issues/8
 # Until Ubuntu upgrade.


### PR DESCRIPTION
As per this slack thread: https://harrison-ai.slack.com/archives/C03S32UBFL2/p1730757854360519


Benchmark on randomly chosen files from the CTC cache:

```
1.2.11
np.mean(times)=1.9286178301761645, np.std(times)=0.06485639280564721, np.min(times)=1.8074659667909145, np.max(times)=2.2263533268123865, len(times)=101

1.2.13
np.mean(times)=1.664339867079317, np.std(times)=0.08087228980916963, np.min(times)=1.5270744245499372, np.max(times)=2.0380705669522285, len(times)=101

1.3.1
np.mean(times)=1.6679777112780232, np.std(times)=0.05479970442945612, np.min(times)=1.5598770808428526, np.max(times)=1.8912039399147034, len(times)=101
```