### PR TITLE
chore: Update base image and packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,12 @@ Our goal is to provide a base Docker image for the [Coder](https://coder.com/) e
 
 ## 🔧 What’s inside ?
 
-Currently we provide a single image based on [Coder’s “Enterprise Base” Docker image](https://hub.docker.com/r/codercom/enterprise-base), with the following additional tools included:
+Currently we provide a single image based on [Coder’s “Example Base” Docker image](https://hub.docker.com/r/codercom/example-base), with the following additional tools included:
 
-* Python 3.8 (`python3` would be symlinked to `python3.8`)
+* Python 3.10
 * Python 3.11
+* Python 3.12
+* [UV](https://docs.astral.sh/uv/)
 * [AWS CLI](https://aws.amazon.com/cli/)
 * [Kubernetes CL tool (`kubectl`)](https://kubernetes.io/docs/reference/kubectl/)
 * other useful utilities (`ffmpeg`, `libsm6`, `libxext6`, `direnv`, `net-tools`, `iputils-ping`, `dnsutils`, `iproute2`, `tmux`, `bash-completion`, `zsh`, `emacs`, `nano`)

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,10 +1,9 @@
-# Pinned to 2023-03-14 version of "ubuntu" tag
-FROM codercom/enterprise-base@sha256:991819021919f7e7132f8843f9b49de7c7072e6c4e1e358c6a9d0ba0587f4c87
+FROM codercom/example-base:ubuntu-20260223
 
 USER root
 
 RUN sed -i 's#/archive.ubuntu.com#/au.archive.ubuntu.com#g' /etc/apt/sources.list \
-    # Adding deadsnakes ppa to install more recent Python versions packaged for Ubuntu.
+    # Adding deadsnakes ppa to install more Python versions packaged for Ubuntu.
     && add-apt-repository ppa:deadsnakes/ppa \
     && apt-get update \
     && apt-get install --no-install-recommends -y \
@@ -20,21 +19,23 @@ RUN sed -i 's#/archive.ubuntu.com#/au.archive.ubuntu.com#g' /etc/apt/sources.lis
         jq \
         iproute2 \
         iputils-ping \
+        libmagic1 \
         libsm6 \
         libxext6 \
         net-tools \
         openssh-client \
-        python3.8 \
-        python3.8-venv \
+        python3.10 \
+        python3.10-dev \
+        python3.10-venv \
+        python3.10-distutils \
         python3.11 \
         python3.11-dev \
         python3.11-venv \
         python3.11-distutils \
-        # --- python 3.10 needed for new projects ---
-        python3.10-dev \        
-        python3.10-venv \
-        python3.10-distutils \        
-        # utils ---
+        python3.12 \
+        python3.12-dev \
+        python3.12-venv \
+    # utils ---
         tmux \
         unzip \
         zsh \
@@ -63,39 +64,39 @@ RUN sed -i 's#/archive.ubuntu.com#/au.archive.ubuntu.com#g' /etc/apt/sources.lis
 RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen \
     && locale-gen \
     && update-locale LANG=en_US.UTF-8
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
+ENV LANG=en_US.UTF-8
+ENV LANGUAGE=en_US:en
+ENV LC_ALL=en_US.UTF-8
 
-RUN pip install -Uq pip pip-tools
+# RUN pip install -Uq pip pip-tools
 ENV PATH="${PATH}:/home/coder/.local/bin"
 
-ARG S5CMD_VERSION=2.1.0
+ARG S5CMD_VERSION=2.3.0
 RUN curl -L -o "/tmp/s5cmd.tar.gz" "https://github.com/peak/s5cmd/releases/download/v${S5CMD_VERSION}/s5cmd_${S5CMD_VERSION}_Linux-64bit.tar.gz" && \
     tar -xzf /tmp/s5cmd.tar.gz -C /tmp && \
     cp -p /tmp/s5cmd /usr/local/bin && \
     rm -rf /tmp/s5cmd*
 
-ARG RCLONE_VERSION=1.62.2
+ARG RCLONE_VERSION=1.73.2
 RUN curl -L -o "/tmp/rclone.zip" "https://github.com/rclone/rclone/releases/download/v${RCLONE_VERSION}/rclone-v${RCLONE_VERSION}-linux-amd64.zip" && \
     unzip /tmp/rclone.zip -d /tmp && \
     cp -p /tmp/rclone-v${RCLONE_VERSION}-linux-amd64/rclone /usr/local/bin && \
     rm -rf /tmp/rclone*
 
-ARG AWS_VERSION=2.7.18
+ARG AWS_VERSION=2.34.7
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-${AWS_VERSION}.zip" -o "/tmp/awscliv2.zip" && \
     unzip -q /tmp/awscliv2.zip -d /tmp && \
     /tmp/aws/install && \
     rm -rf /tmp/aws /tmp/awscliv2.zip
 
-ARG KUBE_VERSION=1.22.12
+ARG KUBE_VERSION=1.35.2
 RUN curl -LO "https://dl.k8s.io/release/v${KUBE_VERSION}/bin/linux/amd64/kubectl" && \
     chmod +x kubectl && \
     mv kubectl /usr/local/bin
 
 # zlib packed in ubuntu is of version 1.12.11,
 # while newer versions give faster reads of gz files.
-ARG ZLIB_VERSION=1.3.1
+ARG ZLIB_VERSION=1.3.2
 RUN curl -L -o "/tmp/zlib.zip" "https://github.com/madler/zlib/releases/download/v${ZLIB_VERSION}/zlib${ZLIB_VERSION//./}.zip" && \
     unzip /tmp/zlib.zip -d /tmp && \
     cd /tmp/zlib-${ZLIB_VERSION} && \
@@ -104,11 +105,7 @@ RUN curl -L -o "/tmp/zlib.zip" "https://github.com/madler/zlib/releases/download
     cd / && \
     rm -rf /tmp/zlib*
 
-# Workaround issue described here https://github.com/harrison-ai/cobalt-docker-coder-dev/issues/8
-# Until Ubuntu upgrade.
-RUN curl -L -o "/tmp/sudo.deb" https://github.com/sudo-project/sudo/releases/download/SUDO_1_9_14p3/sudo_1.9.14-4_ubu2004_amd64.deb && \
-    dpkg -i /tmp/sudo.deb && \
-    rm -rf /tmp/sudo.deb
+COPY --from=ghcr.io/astral-sh/uv:0.10.10 /uv /uvx /bin/
 
 RUN ssh-keyscan github.com 2>/dev/null > /etc/ssh/ssh_known_hosts
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -11,4 +11,4 @@ fi
 
 IMAGE_NAME="$1"
 
-docker build -t "${IMAGE_NAME}:base" base
+docker buildx build --platform linux/amd64 -t "${IMAGE_NAME}:base" base


### PR DESCRIPTION
Base image is updated from Ubuntu 20.04 to 24.04
Updated Python versions and packages
Added `uv`